### PR TITLE
Traducir descripciones de desempeño y prostitución

### DIFF
--- a/prostitu/spanish/cpr_laamp_modifiers_l_spanish.yml
+++ b/prostitu/spanish/cpr_laamp_modifiers_l_spanish.yml
@@ -1,13 +1,13 @@
 ﻿l_spanish:
 
-cpr_laamp_1000_success_employer_modifier: "Entertained by Skillful Performance"
-cpr_laamp_1000_success_employer_modifier_desc: "This character has been moved by a performance of remarkable quality, bringing temporary respite from the burdens of rule and enhancing their diplomatic presence."
+cpr_laamp_1000_success_employer_modifier: "Entretenido por una actuación magistral"
+cpr_laamp_1000_success_employer_modifier_desc: "Este personaje ha sido conmovido por una actuación de calidad notable, brindándole un respiro temporal de las cargas del gobierno y realzando su presencia diplomática."
 
-cpr_laamp_1000_failure_employer_modifier: "Subjected to Painful Performance"
-cpr_laamp_1000_failure_employer_modifier_desc: "This character has recently endured an entertainment of questionable quality, leaving them more irritable and less composed in diplomatic matters."
+cpr_laamp_1000_failure_employer_modifier: "Sometido a una actuación dolorosa"
+cpr_laamp_1000_failure_employer_modifier_desc: "Este personaje ha soportado recientemente un entretenimiento de calidad dudosa, dejándolo más irritable y menos sereno en asuntos diplomáticos."
 
-cpr_laamp_1000_deception_success_employer_modifier: "Unwittingly Manipulated"
-cpr_laamp_1000_deception_success_employer_modifier_desc: "This character has been subtly manipulated through entertainment, believing themselves to have experienced something genuine while actually revealing vulnerabilities and secrets. Their judgment is compromised without their knowledge."
+cpr_laamp_1000_deception_success_employer_modifier: "Manipulado sin saberlo"
+cpr_laamp_1000_deception_success_employer_modifier_desc: "Este personaje ha sido sutilmente manipulado mediante un entretenimiento, creyendo haber vivido algo genuino mientras en realidad revelaba vulnerabilidades y secretos. Su juicio está comprometido sin que lo sepa."
 
-cpr_laamp_1000_deception_failure_employer_modifier: "Heightened Suspicion"
-cpr_laamp_1000_deception_failure_employer_modifier_desc: "Having detected an attempt at manipulation disguised as entertainment, this character has become more vigilant and suspicious, making them harder to deceive but also more stressed and paranoid."
+cpr_laamp_1000_deception_failure_employer_modifier: "Sospecha incrementada"
+cpr_laamp_1000_deception_failure_employer_modifier_desc: "Habiendo detectado un intento de manipulación disfrazado de entretenimiento, este personaje se ha vuelto más vigilante y desconfiado, lo que lo hace más difícil de engañar pero también más estresado y paranoico."

--- a/prostitu/spanish/replace/zzz_cpr_carn_triggers_l_spanish.yml
+++ b/prostitu/spanish/replace/zzz_cpr_carn_triggers_l_spanish.yml
@@ -1,21 +1,22 @@
 ﻿l_spanish:
- carn_cannot_have_max_number_of_slave_prostitutes: "Cannot have more than [EmptyScope.ScriptValue('carn_max_slave_prostitutes_per_owner')|0] slaves working as prostitutes"
+ carn_cannot_have_max_number_of_slave_prostitutes: "No puede tener más de [EmptyScope.ScriptValue('carn_max_slave_prostitutes_per_owner')|0] esclavos trabajando como prostitutas"
 
- carn_not_effective_age_under_value_cutoff: "Age is not less than $VALUE|0$"
+ carn_not_effective_age_under_value_cutoff: "La edad no es menor que $VALUE|0$"
 
- carn_i_can_have_sex_trigger: "You can have sex"
- carn_not_i_can_have_sex_trigger: "You cannot have sex"
- carn_they_can_have_sex_trigger: "[CHARACTER.GetShortUIName|U] can have sex"
- carn_not_they_can_have_sex_trigger: "[CHARACTER.GetShortUIName|U] cannot have sex"
- carn_can_have_sex_trigger: "Can have sex"
- carn_not_can_have_sex_trigger: "Cannot have sex"
+ carn_i_can_have_sex_trigger: "Puedes tener sexo"
+ carn_not_i_can_have_sex_trigger: "No puedes tener sexo"
+ carn_they_can_have_sex_trigger: "[CHARACTER.GetShortUIName|U] puede tener sexo"
+ carn_not_they_can_have_sex_trigger: "[CHARACTER.GetShortUIName|U] no puede tener sexo"
+ carn_can_have_sex_trigger: "Puede tener sexo"
+ carn_not_can_have_sex_trigger: "No puede tener sexo"
 
- carn_i_accepts_prostitution_trigger: "Prostitution is accepted by your faith or culture"
- carn_not_i_accepts_prostitution_trigger: "Prostitution is #bold not#! accepted by your faith or culture"
- carn_they_accepts_prostitution_trigger: "Prostitution is accepted by [CHARACTER.GetShortUINamePossessive|U] faith or culture"
- carn_not_they_accepts_prostitution_trigger: "Prostitution is #bold not#! accepted by [CHARACTER.GetShortUINamePossessive|U] faith or culture"
- carn_accepts_prostitution_trigger: "Prostitution is accepted by faith or culture"
- carn_not_accepts_prostitution_trigger: "Prostitution is  #bold not#! accepted by faith or culture"
+ carn_i_accepts_prostitution_trigger: "La prostitución es aceptada por tu fe o cultura"
+ carn_not_i_accepts_prostitution_trigger: "La prostitución #bold no#! es aceptada por tu fe o cultura"
+ carn_they_accepts_prostitution_trigger: "La prostitución es aceptada por la fe o cultura de [CHARACTER.GetShortUINamePossessive|U]"
+ carn_not_they_accepts_prostitution_trigger: "La prostitución #bold no#! es aceptada por la fe o cultura de [CHARACTER.GetShortUINamePossessive|U]"
+ carn_accepts_prostitution_trigger: "La prostitución es aceptada por la fe o cultura"
+ carn_not_accepts_prostitution_trigger: "La prostitución #bold no#! es aceptada por la fe o cultura"
 
- cpr_may_learn_secret_tooltip: "[secret_learner.GetShortUIName|U] may learn a secret from [secret_knower.GetShortUIName]"
+ cpr_may_learn_secret_tooltip: "[secret_learner.GetShortUIName|U] puede aprender un secreto de [secret_knower.GetShortUIName]"
  cpr_empty_tooltip: ""
+


### PR DESCRIPTION
## Summary
- Localize performance modifiers into Spanish
- Translate sexual capability and prostitution acceptance triggers to Spanish

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fbd74689c8327862b2cd60d930642