### PR TITLE
Remove duplicate Spanish character window GUI file

### DIFF
--- a/Carna/spanish/carn_character_window_gui_l_spanish.yml
+++ b/Carna/spanish/carn_character_window_gui_l_spanish.yml
@@ -1,3 +1,0 @@
-﻿l_spanish:
-carn_cv_spouses_heading:0 "$SECONDARY_SPOUSES$ #weak ([GetDataModelSize(CharacterWindow.GetSecondarySpouses)])#!"
-carn_cv_concubines_heading:0 "$doctrine_concubines_name$ #weak ([GetDataModelSize(CharacterWindow.GetConcubines)])#!"


### PR DESCRIPTION
## Summary
- remove outdated duplicate `carn_character_window_gui_l_spanish.yml`
- verified `Carna/spanish/gui/carn_character_window_gui_l_spanish.yml` contains the desired localization entries

## Testing
- `yamllint Carna/spanish/gui/carn_character_window_gui_l_spanish.yml` *(fails: command not found)*
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_688fd1382ae88327965eb7e39c59cfe0